### PR TITLE
WIP: build on macOS

### DIFF
--- a/post_processing_software/CMakeLists.txt
+++ b/post_processing_software/CMakeLists.txt
@@ -23,6 +23,8 @@ configure_file(cl/stabilizer_kernel.cl cl/stabilizer_kernel.cl)
 include_directories(include)
 include_directories(/usr/local/include/eigen3)
 include_directories(${PYTHON_INCLUDE_DIRS})
+include_directories(/usr/local/include)
+include_directories(/usr/local/lib/python3.9/site-packages/numpy/core/include)
 set(ALL_LIBS
         ${OpenCV_LIBS}
 )

--- a/post_processing_software/include/levenbergMarquardt.hpp
+++ b/post_processing_software/include/levenbergMarquardt.hpp
@@ -192,7 +192,7 @@ template <typename _Tp> struct calc_timing_from_image : Functor<double>
 					int imapy = round(mapy);
 					//もしも画像の範囲内にあれば
 					if((0<=imapx)&&(imapx<vecFrames[0].cols)&&(0<=imapy)&&(imapy<vecFrames[0].rows)){
-						pixelBuff.at<cv::Vec3b>(imapy,imapx) = vecFrames[i*cLen].at<cv::Vec3b>(v,u);
+						pixelBuff.at<cv::Vec3b>(imapy,imapx) = vecFrames[i*cLen].template at<cv::Vec3b>(v,u);
 					}
 				}
 			}
@@ -240,7 +240,7 @@ template <typename _Tp> struct calc_timing_from_image : Functor<double>
 						int imapy = round(mapy);
 						//もしも画像の範囲内にあれば
 						if((0<=imapx)&&(imapx<vecFrames[0].cols)&&(0<=imapy)&&(imapy<vecFrames[0].rows)){
-							pixelBuff2.at<cv::Vec3b>(imapy,imapx) = vecFrames[j].at<cv::Vec3b>(v,u);//ここもiではなくjである。
+							pixelBuff2.at<cv::Vec3b>(imapy,imapx) = vecFrames[j].template at<cv::Vec3b>(v,u);//ここもiではなくjである。
 						}
 					}
 				}


### PR DESCRIPTION
I couldn't fix including of Python libraries, need help with that. 

Also I've now encountered a problem where build succeeds, but pixelwise stabiliser fails like that:

```
$ ./pixelwise_stabilizer -i ~/vgdata/GOPR0907.MP4 -c Session4 -l Session4 -j ~/vgdata/broken.json -z 1.2 -o ~/vgdata
> libc++abi.dylib: terminating with uncaught exception of type char const*
> videoPass /Users/naoru/vgdata/GOPR0907.MP4[1]    52264 abort      ./pixelwise_stabilizer -i ~/vgdata/GOPR0907.MP4 -c Session4 -l Session4 -j  -
```

The same command worked before so there's nothing wrong with video, gyro data or camera calibration file.

I'm going to unleash all my printf power to debug this issue, @yossato if you have any ideas please share. 